### PR TITLE
Onderscheid tussen metadata over AD en metadata over stelsel

### DIFF
--- a/src/main/java/org/acme/AuthenticatieDienstResource.java
+++ b/src/main/java/org/acme/AuthenticatieDienstResource.java
@@ -60,7 +60,7 @@ public class AuthenticatieDienstResource {
                     List<Map<String, Object>> clients = client.dienstverleners().stream()
                             .map(dv -> TemplateUtils.obtainClients(dv, ad, oidcClientTemplate, samlClientTemplate))
                             .collect(Collectors.toList());
-                    return new AuthenticatieDienst(ad.name, ad.description, clients);
+                    return new AuthenticatieDienst(ad.name, ad.fullname, clients);
                 })
                 .collect(Collectors.toSet());
     }

--- a/src/main/java/org/acme/model/AuthenticatieDienst.java
+++ b/src/main/java/org/acme/model/AuthenticatieDienst.java
@@ -1,36 +1,47 @@
 package org.acme.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
 
 public class AuthenticatieDienst {
 
     public String name;
-    public String description;
     public String iss;
-    public String classification;
-    public String schemeVersion;
-    public String src;
-    public String archiveURI;
-    public Long publicationSerial;
-    public LocalDateTime publicationDate;
-    public LocalDateTime nextUpdate;
-    public LocalDateTime validUntil;
+
+    public String fullname;
+    @JsonProperty("fullname+nl")
+    public String fullnameNl;
+    @JsonProperty("fullname+en")
+    public String fullnameEn;
+
+    public String logo;
+    public Set<String> LoA;
+
+    @JsonProperty("SAML-metadata")
+    public String samlMetadata;
+
+    @JsonProperty("OIDC-metadata")
+    public String oidcMetadata;
 
     public Collection DVs;
 
     public AuthenticatieDienst() {
     }
 
-    public AuthenticatieDienst(String name, String description) {
-        this.name = name;
-        this.description = description;
+    public AuthenticatieDienst(String name, String fullname) {
+        this(name, fullname, new ArrayList());
     }
 
 
-    public AuthenticatieDienst(String name, String description, Collection DVs) {
+    public AuthenticatieDienst(String name, String fullname, Collection DVs) {
         this.name = name;
-        this.description = description;
+        this.fullname = fullname;
+        this.fullnameNl = fullname;
+        this.fullnameEn = fullname;
         this.DVs = DVs;
     }
 }

--- a/src/main/java/org/acme/model/StelselMetadata.java
+++ b/src/main/java/org/acme/model/StelselMetadata.java
@@ -1,0 +1,18 @@
+package org.acme.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class StelselMetadata {
+    public String iss;
+    public String classification;
+    public String schemeVersion;
+    public String src;
+    public String archiveURI;
+    public Long publicationSerial;
+    public LocalDateTime publicationDate;
+    public LocalDateTime nextUpdate;
+    public LocalDateTime validUntil;
+
+    public List<AuthenticatieDienst> ADs;
+}

--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -139,9 +139,26 @@ components:
       properties:
         name:
           type: string
-        description:
+        iss:
           type: string
-        clients:
+        fullname:
+          type: string
+        fullname+nl:
+          type: string
+        fullname+en:
+          type: string
+        logo:
+          type: string
+        LoA:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        SAML-metadata:
+          type: string
+        OIDC-metadata:
+          type: string
+        DVs:
           type: array
     Dienstverlener:
       type: object
@@ -150,5 +167,30 @@ components:
           type: string
         description:
           type: string
-        providers:
+        iss:
+          type: string
+        classification:
+          type: string
+        schemeVersion:
+          type: string
+        src:
+          type: string
+        archiveURI:
+          type: string
+        publicationSerial:
+          format: int64
+          type: integer
+        publicationDate:
+          $ref: '#/components/schemas/LocalDateTime'
+        nextUpdate:
+          $ref: '#/components/schemas/LocalDateTime'
+        validUntil:
+          $ref: '#/components/schemas/LocalDateTime'
+        ADs:
           type: array
+        MDs:
+          type: array
+    LocalDateTime:
+      format: date-time
+      type: string
+      example: 2022-03-10T12:15:50


### PR DESCRIPTION
Op basis van https://github.com/rschaar-logius/PoC-toegang/blob/main/stelselMetadata.json lijkt er wat van de velden gesplitst te moeten worden:
- een deel lijkt te gaan over metadata over het stelsel zelf: `iss`, `classification`, `scheme-version`, `src`, `archiveURI`, `publicationSerial`, `publicationDate`, `nextUpdate`, `validUntil`
- de rest lijkt te gaan over de specifieke ads: `iss`, `name`, `fullname`, `fullname+nl`, `fullname+en`, `logo`, `LoA`, `SAML-metadata`, `OIDC-metadata`